### PR TITLE
Add SAE training.

### DIFF
--- a/notebooks/sae_training.ipynb
+++ b/notebooks/sae_training.ipynb
@@ -1,0 +1,290 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b7f7251-0f11-43ed-9b55-24c0fd535e1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def install_dependencies():\n",
+    "    ! pip install datasets\n",
+    "    ! pip install torch==2.4.*\n",
+    "    ! pip install ipywidgets\n",
+    "    ! pip install transformers\n",
+    "    ! pip install wandb\n",
+    "    ! git clone git@github.com:amirabdullah19852020/sae.git | true\n",
+    "    ! cd sae && ls -a && pip install .\n",
+    "    ! cd .. && pip install . --upgrade\n",
+    "\n",
+    "install_dependencies()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cda9f755-3e79-4453-b769-1b4bb8d9888c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from dataclasses import dataclass\n",
+    "\n",
+    "import torch\n",
+    "import wandb\n",
+    "\n",
+    "from datasets import load_dataset, concatenate_datasets\n",
+    "from huggingface_hub import upload_folder\n",
+    "from sae import SaeConfig, SaeTrainer, TrainConfig\n",
+    "from sae.data import chunk_and_tokenize\n",
+    "from textwrap import dedent\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "from transformers import AutoModelForCausalLM\n",
+    "from QuantaTextToSql import sql_interp_model_location\n",
+    "from QuantaTextToSql.ablate.load_model import free_memory\n",
+    "\n",
+    "\n",
+    "all_cs_num = [1, 2, 3]\n",
+    "all_model_num = [0, 1, 2, 3]\n",
+    "\n",
+    "# This is essentially the same as \"num_epochs\" or number of times the SAE sees each data point.\n",
+    "dataset_multiplication_factor = 3\n",
+    "\n",
+    "wandb_project_name = \"sql_interp_saes\"\n",
+    "sae_repo_name = \"withmartian/sql_interp_saes\"\n",
+    "\n",
+    "wandb.init(project=wandb_project_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "853a9ec5-aebd-4443-81ef-27461e1d7d3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@dataclass\n",
+    "class ModelDatasetFullName:\n",
+    "    model_id: str\n",
+    "    dataset_id: str\n",
+    "    full_dataset_name: str\n",
+    "    full_model_name: str\n",
+    "\n",
+    "# Tinystories only.\n",
+    "selected_model_ids = [1]\n",
+    "\n",
+    "# From cs1 through to cs3.\n",
+    "# Need to figure out a dataset for \"base\" SAE.\n",
+    "dataset_ids = [1, 2, 3]\n",
+    "\n",
+    "alpaca_prompt = \"### Instruction:\\n{}\\n### Context:\\n{}\\n### Response:\\n\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b972865-557c-49bb-acb5-3ab78a827bf5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_model_dataset_full_names = []\n",
+    "\n",
+    "for model_id in selected_model_ids:\n",
+    "    for dataset_id in dataset_ids:\n",
+    "        full_model_name = sql_interp_model_location(model_id, dataset_id)\n",
+    "        full_dataset_name = f\"withmartian/cs{dataset_id}_dataset\"\n",
+    "\n",
+    "        model_dataset_full_name = ModelDatasetFullName(\n",
+    "            model_id=model_id, dataset_id=dataset_id,\n",
+    "            full_dataset_name=full_dataset_name, full_model_name=full_model_name)\n",
+    "\n",
+    "        all_model_dataset_full_names.append(model_dataset_full_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3362642a-4a5a-40f1-b427-6e7465bfde61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_hookpoints(model_id: int):\n",
+    "    if model_id == 1:\n",
+    "        hookpoints= [\"transformer.h.*.attn\", \"transformer.h.*.mlp.act\"]\n",
+    "        return hookpoints\n",
+    "    else:\n",
+    "        raise Exception(f\"Hookpoints not added yet for model id {model_id}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14c3ca12-a4cc-4ba2-9bcf-6da55715a453",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_sae_config(model_dataset_full_name: ModelDatasetFullName, model_abbrev):\n",
+    "    expansion_factor = 4\n",
+    "    k = 32\n",
+    "    sae_config = SaeConfig(expansion_factor=expansion_factor)\n",
+    "    hookpoints = get_hookpoints(model_dataset_full_name.model_id)\n",
+    "\n",
+    "    dataset_name = model_dataset_full_name.full_dataset_name\n",
+    "    model_name = model_dataset_full_name.full_model_name\n",
+    "\n",
+    "    run_name = f\"saes_{model_abbrev}\"\n",
+    "\n",
+    "    custom_config = {\n",
+    "        \"model_name\": model_name, \"dataset_name\": dataset_name,\n",
+    "        \"model_abbrev\":model_abbrev\n",
+    "    }\n",
+    "\n",
+    "    train_config =  TrainConfig(\n",
+    "        sae=sae_config, hookpoints=hookpoints, run_name=run_name, lr=5e-4,\n",
+    "    )\n",
+    "    return train_config, custom_config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "788f95e9-b396-487a-a62c-089c06475315",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def map_text(input_features):\n",
+    "    instruction = input_features['english_prompt']\n",
+    "    context = input_features['create_statement']\n",
+    "    response = input_features['sql_statement']\n",
+    "    final_prompt = alpaca_prompt.format(instruction, context, response)\n",
+    "    output = {\"text\": final_prompt}\n",
+    "    return output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1c72160-78c6-44bc-8204-f009ba7457a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_dataset(model_dataset_full_name: ModelDatasetFullName):\n",
+    "    full_dataset_name = model_dataset_full_name.full_dataset_name\n",
+    "    full_model_name = model_dataset_full_name.full_model_name\n",
+    "\n",
+    "    dataset = load_dataset(\n",
+    "        full_dataset_name,\n",
+    "        split=\"train\",\n",
+    "        trust_remote_code=True,\n",
+    "    )\n",
+    "\n",
+    "    concatenated_dataset =  concatenate_datasets(dataset_multiplication_factor * [dataset]).shuffle()\n",
+    "    tokenizer = AutoTokenizer.from_pretrained(full_model_name)\n",
+    "\n",
+    "    mapped_dataset = concatenated_dataset.map(map_text)\n",
+    "    return mapped_dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f02d6a02-c079-4e52-9318-f39b20c1531e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def upload_saes(train_config, custom_config=None):\n",
+    "    layers = train_config.hookpoints\n",
+    "    for layer in layers:\n",
+    "        folder_path = train_config.run_name\n",
+    "\n",
+    "        if custom_config:\n",
+    "            with open(f\"{folder_path}/model_config.json\", \"w\") as f_out:\n",
+    "                json.dump(custom_config, f_out)\n",
+    "\n",
+    "        model_abbrev = folder_path.replace(\"saes_\", \"\")\n",
+    "\n",
+    "    upload_folder(\n",
+    "        folder_path=f\"{folder_path}\",\n",
+    "        path_in_repo=f\"{folder_path}\",\n",
+    "        repo_id=sae_repo_name,\n",
+    "        commit_message=f\"Uploading saes for {layers} and {model_abbrev}\",  # Optional commit message\n",
+    "        repo_type=\"model\",\n",
+    "        ignore_patterns=[\"*.tmp\", \"*.log\"],  # Optionally exclude specific files\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdbf6523-a5e0-4b38-9111-f9dd41612231",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train_and_upload_sae(model_and_dataset_full_name: ModelDatasetFullName):\n",
+    "\n",
+    "    mdfn = model_and_dataset_full_name\n",
+    "    full_model_name = mdfn.full_model_name\n",
+    "\n",
+    "    model = AutoModelForCausalLM.from_pretrained(\n",
+    "        full_model_name, device_map={\"\": \"cuda\"},\n",
+    "        torch_dtype=torch.bfloat16,\n",
+    "    )\n",
+    "\n",
+    "    model_abbrev = f\"bm{mdfn.model_id}_cs{mdfn.dataset_id}\"\n",
+    "\n",
+    "    print_message = f\"\"\"Working with model {full_model_name} with dataset name\n",
+    "    {mdfn.full_dataset_name} for {model_abbrev}.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    print(dedent(print_message))\n",
+    "\n",
+    "    mapped_dataset = get_dataset(model_and_dataset_full_name)\n",
+    "    tokenizer = AutoTokenizer.from_pretrained(full_model_name)\n",
+    "\n",
+    "    tokenized = chunk_and_tokenize(mapped_dataset, tokenizer)\n",
+    "    train_config, custom_config = get_sae_config(model_and_dataset_full_name, model_abbrev)\n",
+    "    run_name = train_config.run_name\n",
+    "\n",
+    "    print(f'Prepping trainer for {model_abbrev} with train_config {train_config}')\n",
+    "\n",
+    "    trainer = SaeTrainer(train_config, tokenized, model)\n",
+    "\n",
+    "    trainer.fit()\n",
+    "\n",
+    "    upload_saes(train_config=train_config, custom_config=custom_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e2a4429-8190-4a98-bde8-4bd88e21bf0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for mdfn in all_model_dataset_full_names:\n",
+    "    train_and_upload_sae(mdfn)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Hi Philip.
1. Added SAE training for bm1 on cs1, cs2 and cs3. We can add more SAEs simply by:
    a. updating the function `get_sae_config` to support configs for more sae types.
    b. updating the `get_hookpoints` function to return the supported layers.
2. You can see the wandb runs for training here: https://wandb.ai/nlp_and_interpretability/sae?nw=nwuseramirali1985

For the most part, the most important thing is the convergence of the fraction of unexplained variance to 0, which seems to happen.
<img width="1387" alt="Screenshot 2024-11-27 at 7 19 33 AM" src="https://github.com/user-attachments/assets/ad6c34e8-aa45-4fd5-8163-a64c3d952049">

3. I upload all the autoencoders to huggingface hub here, with the naming convention we discussed for the top level models.
https://huggingface.co/withmartian/sql_interp_saes/tree/main
<img width="1180" alt="Screenshot 2024-11-27 at 7 21 18 AM" src="https://github.com/user-attachments/assets/f34af91c-867e-4273-95c9-6ea7a68449a4">


4. Under each `bm*_cs*`, I store autoencoders for each layer under the layer name.
<img width="1063" alt="Screenshot 2024-11-27 at 7 21 53 AM" src="https://github.com/user-attachments/assets/435fcda4-f94a-4361-ade8-9703d5e706dd">


5. I keep a model_config.json under each folder which stores the full model name and dataset name under huggingface (since bm*_cs* may change which model it maps to over time)
<img width="1063" alt="Screenshot 2024-11-27 at 7 22 09 AM" src="https://github.com/user-attachments/assets/9d7593dd-d595-48c3-9bd4-a6eb2dd1f756">


6. I also keep a cfg.json under each layer, which stores the various autoencoder parameters
<img width="1043" alt="Screenshot 2024-11-27 at 7 25 43 AM" src="https://github.com/user-attachments/assets/8ed9702c-6757-444a-aa47-b8d0ef296b20">


It's easy to extend this to the other bm*_cs* in the exact same format, but for now I want to add some interp / statistics with these saes first.
