### PR TITLE
Update sae training to support all models + metrics

### DIFF
--- a/notebooks/sae_training.ipynb
+++ b/notebooks/sae_training.ipynb
@@ -157,6 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# For debugging.\n",
     "get_sae_config(all_model_dataset_full_names[0])"
    ]
   },
@@ -174,16 +175,6 @@
     "    final_prompt = alpaca_prompt.format(instruction, context, response)\n",
     "    output = {\"text\": final_prompt}\n",
     "    return output"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0a8a3c28-f76e-468f-b1a7-d486bfa2d445",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "all_model_dataset_full_names[0].load_model()"
    ]
   },
   {


### PR DESCRIPTION
A small PR that adds two thing.

1. Adds hookpoints for training SAEs on llama3 and qwen and can train/upload them.

<img width="518" alt="Screenshot 2024-12-01 at 6 08 08 PM" src="https://github.com/user-attachments/assets/2e0f7086-63df-4bd6-9a33-0b9051e89c39">

2. Makes sure the SAEs have the metrics uploaded as well. (see this screenshot).

<img width="646" alt="Screenshot 2024-12-01 at 6 07 52 PM" src="https://github.com/user-attachments/assets/5f4a4ce0-c7fd-48f9-88f2-d785184e17dc">
