### PR TITLE
Remove newlines multispaces

### DIFF
--- a/TinySQL/corrupt_data/clean_corrupt_data.py
+++ b/TinySQL/corrupt_data/clean_corrupt_data.py
@@ -56,17 +56,17 @@ class CorruptibleBatchItem(BatchItem):
     
     def print_clean(self):
         full = self.clean_BatchItem.get_alpaca_prompt() + self.clean_BatchItem.sql_statement 
-        print( "Clean: Token=", self.clean_token_str, "TokenizerIndex=", self.clean_tokenizer_index, "PromptTokenIndex=", self.prompt_token_index, "AnswerTokenIndex=", self.answer_token_index, "Prompt+Answer=", full.replace('\n', '\\n') )
+        print( "Clean: Token=", self.clean_token_str, "TokenizerIndex=", self.clean_tokenizer_index, "PromptTokenIndex=", self.prompt_token_index, "AnswerTokenIndex=", self.answer_token_index, "Prompt+Answer=", full )
 
     def print_corrupt(self):
         full = self.corrupt_BatchItem.get_alpaca_prompt() + self.corrupt_BatchItem.sql_statement
-        print( "Corrupt: Token=", self.corrupt_token_str, "TokenizerIndex=", self.corrupt_tokenizer_index, "PromptTokenIndex=", self.prompt_token_index, "AnswerTokenIndex=", self.answer_token_index, "Prompt+Answer=", full.replace('\n', '\\n') )
+        print( "Corrupt: Token=", self.corrupt_token_str, "TokenizerIndex=", self.corrupt_tokenizer_index, "PromptTokenIndex=", self.prompt_token_index, "AnswerTokenIndex=", self.answer_token_index, "Prompt+Answer=", full )
 
     def print_all(self):
         print("Feature name:", self.feature_name)
         if self.feature_name.startswith("Def"):
-            print("Clean statement:", self.create_statement.replace('\n', '\\n') )
-            print("Corrupt statement:", self.corrupt_create_statement.replace('\n', '\\n') )
+            print("Clean statement:", self.create_statement )
+            print("Corrupt statement:", self.corrupt_create_statement )
         else:
             print("Clean prompt:", self.english_prompt)
             print("Corrupt prompt:", self.corrupt_english_prompt)
@@ -77,8 +77,8 @@ class CorruptibleBatchItem(BatchItem):
         print("Answer token index:", self.answer_token_index)
         print("Clean tokenizer index:", self.clean_tokenizer_index)
         print("Corrupt tokenizer index:", self.corrupt_tokenizer_index)
-        print(self.get_alpaca_prompt().replace('\n', '\\n'))
-        print(self.sql_statement.replace('\n', '\\n'))       
+        print(self.get_alpaca_prompt())
+        print(self.sql_statement)       
 
 class CorruptFeatureTestGenerator:
     def __init__(self, model_num: int = UNKNOWN_VALUE, cs_num: int = UNKNOWN_VALUE, tokenizer = None, use_novel_names: bool = False):
@@ -183,7 +183,7 @@ class CorruptFeatureTestGenerator:
                     item.prompt_token_index = clean_prompt_tokens.index(item.clean_tokenizer_index)
 
                 # Token position in the predicted answer of the token that may be corrupted
-                item.answer_token_index = len(clean_prompt_tokens) + clean_answer_tokens.index(item.clean_tokenizer_index)
+                item.answer_token_index = len(clean_prompt_tokens) + clean_answer_tokens.index(item.clean_tokenizer_index) - 1
 
                 
     def _corrupt_eng_table_name(self) -> CorruptibleBatchItem:

--- a/TinySQL/finetune/finetune.py
+++ b/TinySQL/finetune/finetune.py
@@ -239,10 +239,10 @@ def evaluate(args, dataset, model, tokenizer, alpaca_prompt, evaluate_cs_functio
             else:
                 # Print the incorrect predictions
                 print("--------------------------------------------------")
-                print(f"Instruction {i + idx} {dataset_type} set:\n{sample['english_prompt']}\n")
-                print(f"Context {i + idx} {dataset_type} set:\n{sample['create_statement']}\n")
-                print(f"Ground Truth SQL {i + idx} {dataset_type} set:\n{sample['sql_statement']}\n")
-                print(f"Predicted SQL {i + idx} {dataset_type} set:\n{predicted_sql}\n")
+                print(f"Instruction {i + idx} {dataset_type} set: {sample['english_prompt']}")
+                print(f"Context {i + idx} {dataset_type} set: {sample['create_statement']}")
+                print(f"Ground Truth SQL {i + idx} {dataset_type} set: {sample['sql_statement']}")
+                print(f"Predicted SQL {i + idx} {dataset_type} set: {predicted_sql}")
                 print("--------------------------------------------------")
             total_predictions += 1
             evaluation_score_sum += prediction_score
@@ -352,7 +352,7 @@ def main():
         raise ValueError("Model not supported!")
 
     # Use the alpaca prompt
-    alpaca_prompt = """### Instruction:\n{}\n### Context:\n{}\n### Response:\n"""
+    alpaca_prompt = """### Instruction: {} ### Context: {} ### Response: """
 
     if args.interactive:
         # Interactive mode

--- a/TinySQL/finetune/upload_to_martian_hf.py
+++ b/TinySQL/finetune/upload_to_martian_hf.py
@@ -81,7 +81,7 @@ for local_model_name, new_repo_name in zip(local_model_names, new_repo_names):
             commit_message=f"Upload {local_model_name} files",
             token=HUGGINGFACE_TOKEN
         )
-        print(f"Model files from '{local_model_path}' have been uploaded to https://huggingface.co/{repo_id}\n")
+        print(f"Model files from '{local_model_path}' have been uploaded to https://huggingface.co/{repo_id}")
     except Exception as e:
-        print(f"Error uploading model from '{local_model_path}' to '{repo_id}': {e}\n")
+        print(f"Error uploading model from '{local_model_path}' to '{repo_id}': {e}")
 

--- a/TinySQL/training_data/fragments/models.py
+++ b/TinySQL/training_data/fragments/models.py
@@ -37,6 +37,11 @@ class OrderField:
     asc: bool
 
 
+# Remove newlines, multiple spaces, leading/trailing spaces 
+def trim_newlines_and_multiple_spaces(statement: str) -> str:
+    str_list = statement.replace('\n', ' ').replace('    ', ' ').replace('   ', ' ').replace('  ', ' ').strip().split()
+    return ' '.join(str_list)
+
 @dataclass
 class BatchItem:
     command_set: int
@@ -61,9 +66,11 @@ class BatchItem:
         print( "SQL:", self.sql_statement )
 
     def get_alpaca_prompt(self):
-        alpaca_prompt = """### Instruction:\n{}\n### Context:\n{}\n### Response:\n"""
+        alpaca_prompt = """### Instruction: {} ### Context: {} ### Response: """
 
         # Substitute the english_prompt and create_statement into the alpaca_prompt
         alpaca_prompt = alpaca_prompt.format(self.english_prompt, self.create_statement)
+
+        alpaca_prompt = trim_newlines_and_multiple_spaces(alpaca_prompt) + " "
 
         return alpaca_prompt

--- a/TinySQL/training_data/generate_cs1.py
+++ b/TinySQL/training_data/generate_cs1.py
@@ -4,7 +4,7 @@ from .fragments.english_select_from import get_english_select_from_phrase
 from .fragments.english_order_by import get_english_order_by_phrase
 from .sql_create_table import get_sql_create_table
 from .sql_select_from import get_sql_select_from
-from .fragments.models import BatchItem, OrderField, SelectField
+from .fragments.models import BatchItem, OrderField, SelectField, trim_newlines_and_multiple_spaces
 
 
 def get_english_order_by(fields: list[OrderField]) -> str:
@@ -241,15 +241,9 @@ def evaluate_cs1_prediction_score(item, predicted_sql_statement):
     return (points_earned_part1+points_earned_part2, total_points_part1+total_points_part2)
 
 
-# Remove newlines, multiple spaces, leading/trailing spaces and upper case
-def trim_sql_statement(sql_statement: str) -> str:
-    str_list = sql_statement.upper().replace('\n', ' ').strip().split()
-    return ' '.join(str_list)
-
-
 def evaluate_cs1_prediction(item: BatchItem, predicted_sql_statement: str) -> float:
 
-    test_sql_statement = trim_sql_statement(predicted_sql_statement)
+    test_sql_statement = trim_newlines_and_multiple_spaces(predicted_sql_statement).upper()
     if test_sql_statement == "":
         return 0.0
 

--- a/TinySQL/training_data/generate_cs2.py
+++ b/TinySQL/training_data/generate_cs2.py
@@ -2,7 +2,7 @@ from .sql_create_table import get_sql_create_table
 from .sql_select_from import get_sql_select_from
 from .sql_order_by import get_sql_order_by
 from .fragments.models import BatchItem
-from .generate_cs1 import evaluate_cs1_prediction_score, get_english_select_from, get_english_order_by, trim_sql_statement, evaluate_unrecognised_words
+from .generate_cs1 import evaluate_cs1_prediction_score, get_english_select_from, get_english_order_by, trim_newlines_and_multiple_spaces, evaluate_unrecognised_words
 
 
 # Generate a batch of "command set 2" prompts and answers: SELECT xx FROM yy ORDER BY zz DESC
@@ -82,7 +82,7 @@ def evaluate_cs2_prediction_score(item: BatchItem, predicted_sql_statement: str)
 
 def evaluate_cs2_prediction(item: BatchItem, predicted_sql_statement: str) -> float:
 
-    test_sql_statement = trim_sql_statement(predicted_sql_statement)
+    test_sql_statement = trim_newlines_and_multiple_spaces(predicted_sql_statement).upper()
     if test_sql_statement == "":
         return 0.0
     

--- a/TinySQL/training_data/generate_cs3.py
+++ b/TinySQL/training_data/generate_cs3.py
@@ -1,5 +1,5 @@
 from .fragments.models import BatchItem
-from .generate_cs1 import evaluate_cs1_prediction_score_part1, trim_sql_statement, evaluate_unrecognised_words
+from .generate_cs1 import evaluate_cs1_prediction_score_part1, trim_newlines_and_multiple_spaces, evaluate_unrecognised_words
 from .generate_cs2 import evaluate_cs2_prediction_score, generate_cs2
 
 
@@ -81,7 +81,7 @@ def evaluate_cs3_prediction_score(item: BatchItem, predicted_sql_statement: str)
 
 def evaluate_cs3_prediction(item: BatchItem, predicted_sql_statement: str) -> float:
 
-    test_sql_statement = trim_sql_statement(predicted_sql_statement)
+    test_sql_statement = trim_newlines_and_multiple_spaces(predicted_sql_statement).upper()
     if test_sql_statement == "":
         return 0.0
     

--- a/TinySQL/training_data/sql_create_table.py
+++ b/TinySQL/training_data/sql_create_table.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 
 from .fragments.table_names import get_sql_table_name
 from .fragments.field_names import get_sql_table_fields
-from .fragments.models import TableField
+from .fragments.models import TableField, trim_newlines_and_multiple_spaces
 
 
 def get_sql_create_table_from_selected_fields(table_name, selected_fields : List[TableField]) -> Tuple[str, List[Tuple[str, str]], str]:
@@ -24,13 +24,14 @@ def get_sql_create_table_from_selected_fields(table_name, selected_fields : List
     # Add columns
     column_definitions = []
     for field in selected_fields:
-        column_definitions.append(f"    {field.name} {field.type}")
+        column_definitions.append(f" {field.name} {field.type}")
        
     # Combine all parts
-    sql_parts.append(",\n".join(column_definitions))
+    sql_parts.append(", ".join(column_definitions))
     sql_parts.append(" )")
-    
-    return (table_name, selected_fields, "\n".join(sql_parts))
+    sql_statement = trim_newlines_and_multiple_spaces(" ".join(sql_parts))
+
+    return (table_name, selected_fields, sql_statement)
 
 
 

--- a/TinySQL/training_data/sql_order_by.py
+++ b/TinySQL/training_data/sql_order_by.py
@@ -1,6 +1,6 @@
 import random
 from typing import Tuple
-from .fragments.models import OrderField, TableField
+from .fragments.models import OrderField, TableField, trim_newlines_and_multiple_spaces
 
 
 def get_sql_order_by(table_fields : list[TableField]) -> Tuple[list[OrderField], str]:
@@ -31,6 +31,8 @@ def get_sql_order_by(table_fields : list[TableField]) -> Tuple[list[OrderField],
     
     # Build the SELECT statement with proper formatting
     # Add newlines and indentation for better readability
-    sql = "ORDER BY\n    " + ",\n    ".join(formatted_fields)
+    sql = "ORDER BY " + ", ".join(formatted_fields)
     
+    sql = trim_newlines_and_multiple_spaces(sql)
+
     return (order_by_fields, sql)

--- a/TinySQL/training_data/sql_select_from.py
+++ b/TinySQL/training_data/sql_select_from.py
@@ -1,6 +1,6 @@
 import random
 from .fragments.field_names import get_sql_select_fields
-from .fragments.models import SelectField, TableField
+from .fragments.models import SelectField, TableField, trim_newlines_and_multiple_spaces
 
 
 def get_sql_select_from_selected_fields(table_name, selected_fields):
@@ -26,8 +26,10 @@ def get_sql_select_from_selected_fields(table_name, selected_fields):
     if len(formatted_fields) == 1:
         sql = f"SELECT {formatted_fields[0]} FROM {table_name}"
     else:
-        sql = "SELECT\n    " + ",\n    ".join(formatted_fields) + f"\nFROM {table_name}"
+        sql = "SELECT " + ", ".join(formatted_fields) + f" FROM {table_name}"
     
+    sql = trim_newlines_and_multiple_spaces(sql)
+
     return (selected_fields, sql)
 
 

--- a/tests/test_corrupt_data.py
+++ b/tests/test_corrupt_data.py
@@ -18,11 +18,11 @@ class TestCorruptData(unittest.TestCase):
         for i, example in enumerate(examples, 1):
             print(f"\nExample {i} of {example.feature_name}:")
             if example.feature_name.startswith("Def"):
-                print(f"Clean statement  : {example.create_statement.replace('\n', '\\n')}")
-                print(f"Corrupt statement: {example.corrupt_create_statement.replace('\n', '\\n')}")
+                print(f"Clean statement  : {example.create_statement}")
+                print(f"Corrupt statement: {example.corrupt_create_statement}")
             else:
-                print(f"Clean prompt  : {example.english_prompt.replace('\n', '\\n')}")
-                print(f"Corrupt prompt: {example.corrupt_english_prompt.replace('\n', '\\n')}")
+                print(f"Clean prompt  : {example.english_prompt}")
+                print(f"Corrupt prompt: {example.corrupt_english_prompt}")
 
             assert example.clean_token_str != ""
             assert example.corrupt_token_str != ""
@@ -43,14 +43,15 @@ class TestCorruptData(unittest.TestCase):
             assert len(clean_tokens) == len_all_tokens
             assert len(corrupt_tokens) == len_all_tokens
 
+            print(f"Prompt token index: {example.prompt_token_index} {example.answer_token_index} {example.clean_tokenizer_index} {len(clean_tokens)}")
             assert clean_tokens[example.prompt_token_index] == example.clean_tokenizer_index
             assert clean_tokens[example.answer_token_index] == example.clean_tokenizer_index
 
             # PQR TODO This does not work for modelNum==2. Not sure why
             if model_num <= 1: 
                 if corrupt_tokens[example.prompt_token_index] != example.corrupt_tokenizer_index:
-                    print(clean_str.replace('\n', '\\n'))
-                    print(corrupt_str.replace('\n', '\\n'))
+                    print(clean_str)
+                    print(corrupt_str)
                     print( "Bad prompt corrupt token:", example.prompt_token_index, example.corrupt_tokenizer_index, corrupt_tokens[example.prompt_token_index], corrupt_tokens)
                     assert False
                 #if corrupt_tokens[example.answer_token_index] != example.corrupt_tokenizer_index:


### PR DESCRIPTION
Convert all newlines and multiple-successive-spaces to single spaces.
(To avoid the model learning features based on newlines and multiple-successive-spaces in training data)

All models will need retraining.
All unit tests pass - expect those that measure impact of corruption on existing trained models.

After training, all MI analysis and SAE training will need to be rerun. 