### PR TITLE
better dataset metadata

### DIFF
--- a/TinySQL/corrupt_data/clean_corrupt_data.py
+++ b/TinySQL/corrupt_data/clean_corrupt_data.py
@@ -93,30 +93,39 @@ class CorruptFeatureTestGenerator:
         
         # Original sample data
         self.clean_table_names = ["people", "inventory", "orders", "products", 
-                                        "flights", "favorites", "schedule", "items", "users",
-                                        "links", "messages", "countries", "campaigns"]
+                                        # "flights", not 1 token 
+                                        #"favorites", 
+                                        #"schedule", 
+                                        "items", "users",
+                                        "links", 
+                                        #"messages", 
+                                        #"countries", 
+                                        #"campaigns"
+                                        ]
         
         self.synonym_table_names = {
             "people": "individuals", 
             "inventory": "stock", 
             "orders": "requests",
             "products": "goods", 
-            "flights": "trips", 
-            "favorites": "picks", 
-            "schedule": "timetable", 
+            #"flights": "trips", 
+            #"favorites": "picks", 
+            #"schedule": "timetable", 
             "items": "objects",
             "users": "customers", 
             "links": "connections", 
-            "messages": "discussions", 
-            "countries": "nations", 
-            "campaigns": "initiatives"
+            #"messages": "discussions", 
+            #"countries": "nations", 
+            #"campaigns": "initiatives"
         }
         
         self.novel_table_names = ["star", "very", "apple", "blue", "orange"]
         
         self.clean_field_names = ["price", "count", "amount", "total", "name", "code", 
                                  "number", "label", "type", "category", "status", 
-                                 "title", "date", "value", "quantity", "rating", 
+                                 "title", "date", "value", 
+                                 # "quantity", Not 1 token 
+                                 "rating", 
                                  "color", "size", "weight", "duration"]
         
         self.synonym_field_names = {
@@ -134,7 +143,7 @@ class CorruptFeatureTestGenerator:
             "title": "heading",
             "date": "time",
             "value": "amount",
-            "quantity": "volume",
+            #"quantity": "volume",
             "rating": "score",
             "color": "shade",
             "size": "dimension",
@@ -167,10 +176,10 @@ class CorruptFeatureTestGenerator:
             order_by_field = random.choice(fields)
             direction = random.choice(self.directions)
             order_by_clause = f" ORDER BY {order_by_field} {direction}"
-            order_by_english = f" ordered by {self.synonym_field_names[order_by_field] if self.use_synonyms_field==True else order_by_field} in {'descending' if direction == 'DESC' else 'ascending'} order"
+            order_by_english = f" ordered by {self.synonym_field_names[order_by_field] if self.use_synonyms_field else order_by_field} in {'descending' if direction == 'DESC' else 'ascending'} order"
             order_by_fields = [SelectField(order_by_field, direction, order_by_field)]
         
-        english_prompt = f"show me the {eng_fields} from the {table_name.synonym if self.use_synonyms_table==True else table_name.name} table{order_by_english}"
+        english_prompt = f"show me the {eng_fields} from the {table_name.synonym if self.use_synonyms_table else table_name.name} table{order_by_english}"
         sql_statement = f"SELECT {crt_fields} FROM {table_name.name}{order_by_clause}"
         
         return BatchItem(

--- a/TinySQL/training_data/__init__.py
+++ b/TinySQL/training_data/__init__.py
@@ -43,3 +43,5 @@ from .generate_cs3 import generate_cs3, evaluate_cs3_prediction, evaluate_cs3_pr
 from .generate_csn import generate_csn
 
 from .generate_utils import (generate_inputs_from_prompt, generate_inputs_from_BatchItems, output_inference_text)
+
+from .generate_datasets import batchitem_to_dict, dict_to_batchitem, generate_dataset 

--- a/TinySQL/training_data/fragments/models.py
+++ b/TinySQL/training_data/fragments/models.py
@@ -7,13 +7,15 @@ class TableField:
     """Represents a field and its metadata"""
     name: str
     type: str # INTEGER, BIGINT, DECIMAL, NUMERIC, FLOAT, DOUBLE, VARCHAR, CHAR, TEXT, DATE, DATETIME, TIMESTAMP, BOOLEAN, UUID, BLOB, JSON, JSONB
-    synonym: str # english synonyms for the field name
+    synonym: str # english synonym for the field name
+    use_synonym: bool = False # whether to use the synonym in the Instructions (english statement)
 
 @dataclass
 class TableName:
     """Represents a table and a synonym"""
     name: str
     synonym: str # english synonym for the table name
+    use_synonym: bool = False # whether to use the synonym in the Instructions (english statement)
 
 
 @dataclass
@@ -21,6 +23,7 @@ class SelectField:
     name: str
     aggregate: str # SUM, AVG, MIN, MAX, COUNT, ""
     synonym: str # english synonym for the field name
+    use_synonym: bool = False # whether to use the synonym in the Instructions (english statement)
 
     @property
     def aggregate_of_field(self):

--- a/TinySQL/training_data/generate_cs2.py
+++ b/TinySQL/training_data/generate_cs2.py
@@ -14,7 +14,8 @@ def generate_cs2(batch_size, order_by_clause_probability=0.9, use_aggregates=Fal
         (table_name, table_fields, create_table_statement) = get_sql_create_table(min_cols=min_cols, max_cols=max_cols)
 
         (selected_fields, sql_select_statement) = get_sql_select_from(table_name, table_fields, use_aggregates)
-        english_select_from_prompt = get_english_select_from(table_name, selected_fields, use_synonyms)
+        
+        (english_select_from_prompt, table_name, selected_fields) = get_english_select_from(table_name, selected_fields, use_synonyms)
 
         # Randomly decide whether to include an ORDER BY clause
         include_order_by = i < batch_size * order_by_clause_probability
@@ -28,7 +29,7 @@ def generate_cs2(batch_size, order_by_clause_probability=0.9, use_aggregates=Fal
 
         batch_item = BatchItem(
             command_set=2,
-            table_name=TableName(name=table_name.name, synonym=table_name.synonym),
+            table_name=TableName(name=table_name.name, synonym=table_name.synonym, use_synonym=table_name.use_synonym), 
             table_fields=table_fields,
             create_statement=create_table_statement,
             select=selected_fields,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "TinySQL"
-version = "1.0"
-description = "Tools for use with the quanta text to sql project"
+version = "1.1"
+description = "Tools for use with the TinySQL project"
 authors = [{name = "Philip Quirke et al", email = "philipquirkenz@gmail.com"}]
 keywords = ["SQL", "machine learning", "text to SQL", "interpretable AI"]
 readme = "README.md"  

--- a/tests/test_corrupt_data.py
+++ b/tests/test_corrupt_data.py
@@ -59,7 +59,12 @@ class TestCorruptData(unittest.TestCase):
                 #    assert False
 
         return generator, examples
- 
+
+    def check_words_are_one_token(self, prefix, tokenizer, words):
+        for word in words:
+            if len(tokenizer(word)["input_ids"]) != 1:
+                print(prefix, "Word not 1 token:", word)
+                assert False
 
     # Check that all the clean and corrupt tokens are single tokens
     # So that when we generate the paired clean and corrupt examples, they have the same number of tokens  
@@ -68,21 +73,13 @@ class TestCorruptData(unittest.TestCase):
          
         generator = CorruptFeatureTestGenerator(model_num=1, cs_num=2, tokenizer=tokenizer, use_novel_names=True)
 
-        for word in generator.clean_table_names:
-            assert len(tokenizer(word)["input_ids"]) == 1
-
-        for word in generator.novel_table_names:
-            assert len(tokenizer(word)["input_ids"]) == 1
-
-        for word in generator.clean_field_names:
-            assert len(tokenizer(word)["input_ids"]) == 1
-
-        for word in generator.novel_field_names:
-            assert len(tokenizer(word)["input_ids"]) == 1
-
-        for word in generator.clean_field_types:
-            assert len(tokenizer(word)["input_ids"]) == 1
-
+        self.check_words_are_one_token("clean_table_name", tokenizer, generator.clean_table_names)   
+        self.check_words_are_one_token("novel_table_name", tokenizer, generator.novel_table_names)
+        self.check_words_are_one_token("synonym_table_name", tokenizer, generator.synonym_table_names)
+        self.check_words_are_one_token("clean_field_name", tokenizer, generator.clean_field_names)
+        self.check_words_are_one_token("novel_field_name", tokenizer, generator.novel_field_names)
+        self.check_words_are_one_token("synonym_field_name", tokenizer, generator.synonym_field_names)
+        self.check_words_are_one_token("clean_field_type", tokenizer, generator.clean_field_types)
 
     def test_m1_generate_ENGTABLENAME(self): 
         self.show_examples(ENGTABLENAME, 1, use_novel_names=False)

--- a/tests/test_cs1.py
+++ b/tests/test_cs1.py
@@ -27,10 +27,10 @@ class TestCommandSet1(unittest.TestCase):
 
         (select_fields, _) = get_sql_select_from(table_name, table_fields, False)
 
-        english_select_from = get_english_select_from(table_name, select_fields, False)
+        (english_select_from, table_name, select_fields) = get_english_select_from(table_name, select_fields, False)
         print( "English select (no synonyms):", english_select_from )
 
-        english_select_from = get_english_select_from(table_name, select_fields, True)
+        (english_select_from, table_name, select_fields) = get_english_select_from(table_name, select_fields, True)
         print( "English select (with synonyms):", english_select_from )
 
     # The "ground truth" should score 100%  

--- a/tests/test_cs3.py
+++ b/tests/test_cs3.py
@@ -73,12 +73,17 @@ class TestCommandSet3(unittest.TestCase):
 
         batch_size = 1000
         answer = generate_cs3(batch_size)  
+        print(len(answer))
         for i in range(batch_size):
 
             # Using answer[i], create a JSON style output
             json_answer = {
                 "table_name": answer[i].table_name.name,
+                "table_name_synonym": answer[i].table_name.synonym, # May be identical to table_name 
+                "table_name_use_synonym": answer[i].table_name.use_synonym,
                 "table_fields": [table_field.name for table_field in answer[i].table_fields],
+                "table_field_synonyms": [table_field.synonym for table_field in answer[i].table_fields], # May be identical to table_fields                 
+                "table_field_use_synonyms": [table_field.use_synonym for table_field in answer[i].table_fields],               
                 "select": [select_field.name for select_field in answer[i].select],
                 "order_by": [order_field.name for order_field in answer[i].order_by],
                 "english_prompt": answer[i].english_prompt

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,22 @@
+import unittest
+
+from TinySQL.training_data.generate_cs1 import generate_cs1, evaluate_cs1_prediction
+from TinySQL.training_data.generate_cs2 import generate_cs2, evaluate_cs2_prediction
+from TinySQL.training_data.generate_cs3 import generate_cs3, evaluate_cs3_prediction
+from TinySQL.training_data import generate_dataset
+
+class TestGenerate(unittest.TestCase):
+
+    def test_generate(self):
+        batch_size = 16
+        push_to_hf = False
+
+        use_synonyms = False
+        generate_dataset(batch_size, generate_cs1, evaluate_cs1_prediction, "withmartian/cs1_dataset", use_synonyms, push_to_hf)
+        generate_dataset(batch_size, generate_cs2, evaluate_cs2_prediction, "withmartian/cs2_dataset", use_synonyms, push_to_hf)
+        generate_dataset(batch_size, generate_cs3, evaluate_cs3_prediction, "withmartian/cs3_dataset", use_synonyms, push_to_hf)
+
+        use_synonyms = True
+        generate_dataset(batch_size, generate_cs1, evaluate_cs1_prediction, "withmartian/cs1_dataset_synonyms", use_synonyms, push_to_hf)
+        generate_dataset(batch_size, generate_cs2, evaluate_cs2_prediction, "withmartian/cs2_dataset_synonyms", use_synonyms, push_to_hf)
+        generate_dataset(batch_size, generate_cs3, evaluate_cs3_prediction, "withmartian/cs3_dataset_synonyms", use_synonyms, push_to_hf)


### PR DESCRIPTION
The CorruptFeatureTestGenerator had some sample words which were not 1 token one. 
We want them all to be one token, so that when we generate the paired clean and corrupt examples, the complete prompt/answer has the same number of tokens.
I've commented multi-token sample words, and strengthened the unit test to test all classes of sample words.

I changed the TableName, TableField and SelectField classes to include a "use_synonym" field showing whether a synonym was actually used (based on the 80% rule etc). Updated generate_cs1/2/3. Updated generate_dataset to include this information. Wrote a unit test. The create_statement, english_prompt and sql_statement should be unchanged by this code change.

updated pyproject.toml version
