### PR TITLE
LoadModel and CleanCorrupt improvements

### DIFF
--- a/TinySQL/load_data/load_model.py
+++ b/TinySQL/load_data/load_model.py
@@ -7,7 +7,7 @@ from nnsight import LanguageModel
 
 # Load the tokenizer and trained model for model 1, 2, or 3 and command set 0 (base model), 1, 2, or 3
 # If you are changing the models, consider updating the HF collection withmartian/tinysql as well. 
-def sql_interp_model_location( model_num : int, cs_num : int):
+def sql_interp_model_location( model_num : int, cs_num : int, synonym : bool = True):
 
     if model_num == 0:
         # Used with nnsight tutorials only
@@ -17,15 +17,27 @@ def sql_interp_model_location( model_num : int, cs_num : int):
         if cs_num == 0:
             return "roneneldan/TinyStories-Instruct-2Layers-33M"
 
-        elif cs_num == 1:
-            return "withmartian/sql_interp_bm1_cs1_experiment_1.10"
- 
-        elif cs_num == 2:
-            return "withmartian/sql_interp_bm1_cs2_experiment_2.10"
+        elif synonym:
+            # Semantic models
+            if cs_num == 1:
+                return "withmartian/sql_interp_bm1_cs1_experiment_1.10"
+    
+            elif cs_num == 2:
+                return "withmartian/sql_interp_bm1_cs2_experiment_2.10"
 
-        elif cs_num == 3:
-            return "withmartian/sql_interp_bm1_cs3_experiment_3.10"
-        
+            elif cs_num == 3:
+                return "withmartian/sql_interp_bm1_cs3_experiment_3.10"
+        else:
+            # Non-semantic models
+            if cs_num == 1:
+                return "withmartian/sql_interp_bm1_cs1_experiment_1.8"
+    
+            elif cs_num == 2:
+                return "withmartian/sql_interp_bm1_cs2_experiment_2.8"
+
+            elif cs_num == 3:
+                return "withmartian/sql_interp_bm1_cs3_experiment_3.8"        
+
     elif model_num == 2:
         if cs_num == 0:
             return "Qwen/Qwen2.5-0.5B-Instruct"
@@ -89,8 +101,8 @@ def load_model(model_location, auth_token=None, use_flash_attention=True, device
     return tokenizer, auto_model
 
 
-def load_sql_interp_model( model_num : int, cs_num : int, auth_token=None, use_flash_attention=True, device_map="auto"):
-    model_location = sql_interp_model_location(model_num, cs_num)
+def load_sql_interp_model( model_num : int, cs_num : int, synonym : bool = True,  auth_token=None, use_flash_attention=True, device_map="auto"):
+    model_location = sql_interp_model_location(model_num, cs_num, synonym)
 
     tokenizer, auto_model = load_model(model_location, auth_token=auth_token, use_flash_attention=use_flash_attention, device_map=device_map)
 
@@ -107,14 +119,14 @@ def load_sql_interp_model( model_num : int, cs_num : int, auth_token=None, use_f
     return tokenizer, auto_model
 
 
-def load_tinysql_model( model_num : int, cs_num : int, auth_token=None):
+def load_tinysql_model( model_num : int, cs_num : int, synonym : bool = True, auth_token=None):
 
     if model_num == 1:
-        the_tokenizer, auto_model = load_sql_interp_model(model_num, cs_num, auth_token=auth_token, use_flash_attention=False)
+        the_tokenizer, auto_model = load_sql_interp_model(model_num, cs_num, synonym=synonym, auth_token=auth_token, use_flash_attention=False)
         language_model = LanguageModel(auto_model, the_tokenizer)
         language_model.tokenizer = the_tokenizer
     else:
-        language_model = LanguageModel(sql_interp_model_location(model_num, cs_num), device_map="auto")
+        language_model = LanguageModel(sql_interp_model_location(model_num, cs_num, synonym=synonym), device_map="auto")
 
     return language_model
 

--- a/TinySQL/training_data/fragments/models.py
+++ b/TinySQL/training_data/fragments/models.py
@@ -10,6 +10,11 @@ class TableField:
     synonym: str # english synonym for the field name
     use_synonym: bool = False # whether to use the synonym in the Instructions (english statement)
 
+    @property
+    def name_str(self) -> str:
+        """Return the synonym if `use_synonym` is True, otherwise return the name."""
+        return self.synonym if self.use_synonym else self.name
+    
 @dataclass
 class TableName:
     """Represents a table and a synonym"""
@@ -17,6 +22,10 @@ class TableName:
     synonym: str # english synonym for the table name
     use_synonym: bool = False # whether to use the synonym in the Instructions (english statement)
 
+    @property
+    def name_str(self) -> str:
+        """Return the synonym if `use_synonym` is True, otherwise return the name."""
+        return self.synonym if self.use_synonym else self.name
 
 @dataclass
 class SelectField:
@@ -25,6 +34,10 @@ class SelectField:
     synonym: str # english synonym for the field name
     use_synonym: bool = False # whether to use the synonym in the Instructions (english statement)
 
+    @property
+    def name_str(self) -> str:
+        """Return the synonym if `use_synonym` is True, otherwise return the name."""
+        return self.synonym if self.use_synonym else self.name
     @property
     def aggregate_of_field(self):
         if self.aggregate == "":
@@ -48,7 +61,6 @@ class OrderField:
     name: str
     asc: bool
 
-
 # Remove newlines, multiple spaces, leading/trailing spaces 
 def trim_newlines_and_multiple_spaces(statement: str) -> str:
     str_list = statement.replace('\n', ' ').replace('    ', ' ').replace('   ', ' ').replace('  ', ' ').strip().split()
@@ -59,11 +71,11 @@ class BatchItem:
     command_set: int
     table_name: TableName
     table_fields: List[TableField]
-    create_statement: str
+    create_statement: str # aka Context
     select: List[SelectField]
     order_by: List[OrderField]
-    english_prompt: str
-    sql_statement: str
+    english_prompt: str # aka Instruction
+    sql_statement: str # aka Response
 
     def print(self):
         print( "Command Set:", self.command_set )

--- a/TinySQL/training_data/generate_cs1.py
+++ b/TinySQL/training_data/generate_cs1.py
@@ -94,7 +94,7 @@ def generate_cs1(batch_size, min_cols=2, max_cols=12, use_synonyms=False) -> lis
             english_prompt=english_select_from_prompt,
             sql_statement=sql_select_statement, # ground truth
         )
-        
+
         batch.append(batch_item)
 
     return batch

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,17 @@
+import unittest
+
+from TinySQL.load_data import sql_interp_model_location
+
+
+class TestLoad(unittest.TestCase):
+
+    def test_sql_interp_model_location(self):
+        
+        sql_interp_model_location(0, 0)
+        sql_interp_model_location(1, 0, True)
+        sql_interp_model_location(1, 0, False)
+        sql_interp_model_location(1, 1, True)
+        sql_interp_model_location(1, 1, False)
+        sql_interp_model_location(1, 2, True)
+        sql_interp_model_location(1, 2, False)
+       


### PR DESCRIPTION
Load model functions now have a "semantic = True" param to load semantic/non-semantic models.
Added simple unti-test

Improve clean_corrupt_data.py code but couldn't 100% test it before flight loading time. Sorry. I believe it is better than current version.
 